### PR TITLE
Add a gevent-friendly Player subclass.

### DIFF
--- a/mplayer/__init__.py
+++ b/mplayer/__init__.py
@@ -10,6 +10,7 @@ Step -- use with property access to implement the 'step_property' command
 
 AsyncPlayer -- Player subclass with asyncore integration (POSIX only)
 GPlayer -- Player subclass with GTK/GObject integration
+GeventPlayer -- Player subclass with gevent integration
 QtPlayer -- Player subclass with Qt integration
 
 GtkPlayerView -- provides a basic (as of now) PyGTK widget that embeds MPlayer

--- a/mplayer/gevent1.py
+++ b/mplayer/gevent1.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+import gevent
+from gevent.fileobject import FileObject
+from subprocess import PIPE
+
+from mplayer.core import Player
+from mplayer import misc
+
+
+__all__ = ['GeventPlayer']
+
+
+class GeventPlayer(Player):
+    """Player subclass with gevent integration.
+
+    Mplayer's stdout and stderr are processed in seperate greenlets.
+    This subclass is meant to be used with gevent-based applications.
+
+    Shortcomings:
+        - Class methods _generate_properties() and _generate_methods() use
+          blocking pipe IO and may therefore starve other greenlets.
+        - Method quit() calls wait() on the mplayer process, which will block
+          the calling process until it exits. Note that quit() is called when
+          the Player object is garbage collected.
+
+    """
+
+    def __init__(self, args=(), stdout=PIPE, stderr=None, autospawn=True):
+        super(GeventPlayer, self).__init__(args, autospawn=False)
+        self._stdout = _StdoutWrapper(handle=stdout)
+        self._stderr = _StderrWrapper(handle=stderr, map=map)
+        if autospawn:
+            self.spawn()
+
+
+class _StderrWrapper(misc._StderrWrapper):
+
+    def _attach(self, source):
+        super(_StderrWrapper, self)._attach(FileObject(source))
+        gevent.spawn(self._greenlet_func)
+
+    def _greenlet_func(self):
+        while self._source is not None:
+            self._process_output()
+
+
+class _StdoutWrapper(_StderrWrapper, misc._StdoutWrapper):
+    pass


### PR DESCRIPTION
This requires gevent version 1.0rc1 or greater.
There are a few problems (eg. proc.wait()) but it does the main job
of replacing the stdout and stderr processing threads.

It's worth noting that the non-posix fallback for gevent's FileObject is to use threads anyway. So this is effectively a noop on windows.

I used the async.py code as a guideline for how to implement this.
For now, all this does is allow you to use greenlets instead of threads for IO, but I'd also like to fix any other place where non-gevent-friendly blocking may occur, in particular:
- Player._generate_\* introspection functions use stdout and stderr objects from Popen, the difficulty here is that the code is not structured in such a way that a subclass can fix that without reimplementing the whole function.
- Player.quit() calls subprocess.wait(), this one is trickier...best bet would be to install a SIGCHLD handler. Not sure about non-posix systems.
