### PR TITLE
Ignore KeyError when dealing with mplayer2 (#19)

### DIFF
--- a/mplayer/core.py
+++ b/mplayer/core.py
@@ -243,15 +243,18 @@ class Player(object):
         types = []
         required = 0
         for i, arg in enumerate(args):
-            if not arg.startswith('['):
-                optional = ''
-                required += 1
-            else:
-                arg = arg.strip('[]')
-                optional = '=None'
-            t = mtypes.type_map[arg]
-            sig.append('{0}{1}{2}'.format(t.name, i, optional))
-            types.append('mtypes.{0},'.format(t.__name__))
+            try:
+                if not arg.startswith('['):
+                    optional = ''
+                    required += 1
+                else:
+                    arg = arg.strip('[]')
+                    optional = '=None'
+                t = mtypes.type_map[arg]
+                sig.append('{0}{1}{2}'.format(t.name, i, optional))
+                types.append('mtypes.{0},'.format(t.__name__))
+            except KeyError:
+                pass
         sig = ','.join(sig)
         params = sig.replace('=None', '')
         types = ''.join(types)

--- a/mplayer/core.py
+++ b/mplayer/core.py
@@ -244,17 +244,17 @@ class Player(object):
         required = 0
         for i, arg in enumerate(args):
             try:
-                if not arg.startswith('['):
-                    optional = ''
-                    required += 1
-                else:
-                    arg = arg.strip('[]')
-                    optional = '=None'
                 t = mtypes.type_map[arg]
-                sig.append('{0}{1}{2}'.format(t.name, i, optional))
-                types.append('mtypes.{0},'.format(t.__name__))
             except KeyError:
-                pass
+                continue
+            if not arg.startswith('['):
+                optional = ''
+                required += 1
+            else:
+                arg = arg.strip('[]')
+                optional = '=None'
+            sig.append('{0}{1}{2}'.format(t.name, i, optional))
+            types.append('mtypes.{0},'.format(t.__name__))
         sig = ','.join(sig)
         params = sig.replace('=None', '')
         types = ''.join(types)

--- a/mplayer/core.py
+++ b/mplayer/core.py
@@ -243,16 +243,13 @@ class Player(object):
         types = []
         required = 0
         for i, arg in enumerate(args):
-            try:
-                t = mtypes.type_map[arg]
-            except KeyError:
-                continue
             if not arg.startswith('['):
                 optional = ''
                 required += 1
             else:
                 arg = arg.strip('[]')
                 optional = '=None'
+            t = mtypes.type_map[arg]
             sig.append('{0}{1}{2}'.format(t.name, i, optional))
             types.append('mtypes.{0},'.format(t.__name__))
         sig = ','.join(sig)
@@ -278,10 +275,11 @@ class Player(object):
         proc = subprocess.Popen([cls.exec_path, '-input', 'cmdlist'],
                                 bufsize=-1, stdout=subprocess.PIPE)
         for line in proc.stdout:
+            line = line.decode('utf-8', 'ignore')
             # skip version string at end of mplayer2 output
             if line.startswith("MPlayer"):
                 continue
-            args = line.decode('utf-8', 'ignore').split()
+            args = line.split()
             if not args:
                 continue
             # Separate command name from command args


### PR DESCRIPTION
mplayer.py generate methods based on `mplayer -input cmdlist` output, and mplayer2 adds `MPlayer2 2.0-728-g2c378c7-4+b1 (C) 2000-2012 MPlayer Team` at the bottom of the list. So we have to ignore this line.
